### PR TITLE
Scene context reverse loading

### DIFF
--- a/Editor/Context/GameObjectContextEditor.cs
+++ b/Editor/Context/GameObjectContextEditor.cs
@@ -14,8 +14,6 @@ namespace Doinject.Context
 
             if (Application.isPlaying)
             {
-                if (GUILayout.Button("Dispose"))
-                    gameObjectContext.Dispose();
                 if (GUILayout.Button("Reboot"))
                     gameObjectContext.Reboot();
             }

--- a/Editor/Context/SceneContextEditor.cs
+++ b/Editor/Context/SceneContextEditor.cs
@@ -14,8 +14,6 @@ namespace Doinject.Context
 
             if (Application.isPlaying)
             {
-                if (GUILayout.Button("Dispose"))
-                    sceneContext.Dispose();
                 if (GUILayout.Button("Reboot"))
                     sceneContext.Reboot();
             }

--- a/Runtime/Context/AbstractContextComponent.cs
+++ b/Runtime/Context/AbstractContextComponent.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Mew.Core.Tasks;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -17,6 +15,7 @@ namespace Doinject
         public Context Context { get; protected set; }
         public SceneContextLoader SceneContextLoader { get; protected set; }
         public GameObjectContextLoader GameObjectContextLoader { get; protected set; }
+        public abstract bool IsReverseLoaded { get; }
 
 
         protected abstract IEnumerable<T> GetComponentsUnderContext<T>();
@@ -30,14 +29,6 @@ namespace Doinject
         public void SetArgs(IContextArg arg)
         {
             Arg = arg ?? new NullContextArg();
-        }
-
-        protected async Task InjectIntoUnderContextObjects()
-        {
-            var targets = GetComponentsUnderContext<IInjectableComponent>()
-                .Where(x => x.enabled);
-            await Task.WhenAll(targets.Select(x
-                => Context.Container.InjectIntoAsync(x).AsTask()));
         }
 
         public void Dispose()

--- a/Runtime/Context/AutoContextLoader.cs
+++ b/Runtime/Context/AutoContextLoader.cs
@@ -24,6 +24,9 @@ namespace Doinject
             foreach (var gameObjectContextPrefab in gameObjectContextPrefabs)
                 await Context.GameObjectContextLoader.LoadAsync(gameObjectContextPrefab);
 
+            // If this context is loaded from child scene context, do not load child scene contexts.
+            if (Context.IsReverseLoaded) return;
+
             foreach (var sceneContext in sceneContexts)
                 await Context.SceneContextLoader.LoadAsync(sceneContext, active: true);
         }

--- a/Runtime/Context/GameObjectContext.cs
+++ b/Runtime/Context/GameObjectContext.cs
@@ -10,6 +10,8 @@ namespace Doinject
         private IContext ParentContext { get; set; }
 
         public override Scene Scene => Context.Scene;
+        public override bool IsReverseLoaded => false;
+
 
 
         protected override async void Awake()
@@ -62,8 +64,14 @@ namespace Doinject
             ParentContext?.GameObjectContextLoader.Register(this);
 
             InstallBindings();
+
+            var injectableComponents
+                = GetComponentsUnderContext<IInjectableComponent>().Where(x => x.enabled);
+
             await Context.Container.GenerateResolvers();
-            await InjectIntoUnderContextObjects();
+
+            await Task.WhenAll(injectableComponents.Select(x
+                => Context.Container.InjectIntoAsync(x).AsTask()));
         }
 
         private async Task Shutdown()

--- a/Runtime/Context/IContext.cs
+++ b/Runtime/Context/IContext.cs
@@ -10,5 +10,6 @@ namespace Doinject
         Context Context { get; }
         SceneContextLoader SceneContextLoader { get; }
         GameObjectContextLoader GameObjectContextLoader { get; }
+        bool IsReverseLoaded { get; }
     }
 }

--- a/Runtime/Context/ParentContextLoadingScope.cs
+++ b/Runtime/Context/ParentContextLoadingScope.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Mew.Core.TaskHelpers;
+using UnityEngine.SceneManagement;
+
+namespace Doinject
+{
+    public sealed class ParentContextLoadingScope : System.IDisposable
+    {
+        private static List<Scene> StackedScope { get; set; } = new();
+
+        public static bool Scoped => StackedScope.Any();
+        public static Scene CurrentContext => StackedScope.Last();
+
+        private readonly Scene scene;
+
+        public ParentContextLoadingScope(Scene scene)
+        {
+            this.scene = scene;
+            StackedScope.Add(scene);
+        }
+
+        public void Dispose()
+        {
+            StackedScope.Remove(scene);
+        }
+
+        public static async Task WaitForRelease(CancellationToken cancellationToken = default)
+        {
+            while (StackedScope.Any())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await TaskHelper.NextFrame();
+            }
+        }
+    }
+}

--- a/Runtime/Context/ParentContextLoadingScope.cs.meta
+++ b/Runtime/Context/ParentContextLoadingScope.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 365786cd79d2445c98ea1f74a26aed27
+timeCreated: 1706712099

--- a/Runtime/Context/ParentSceneContextRequirement.cs
+++ b/Runtime/Context/ParentSceneContextRequirement.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using Mew.Core.Assets;
+using Mew.Core.TaskHelpers;
+using UnityEngine;
+
+namespace Doinject
+{
+    public sealed class ParentSceneContextRequirement : MonoBehaviour
+    {
+        [field: SerializeField] public UnifiedScene Scene { get; private set; }
+
+        private ISceneHandle handle;
+
+        public async Task<IContext> ResolveParentContext(SceneContext current)
+        {
+            if (!enabled) return ProjectContext.Instance;
+
+#if UNITY_EDITOR
+            using var scope = new ParentContextLoadingScope(gameObject.scene);
+
+            handle = await UnifiedSceneLoader.LoadAsync(Scene, destroyCancellationToken);
+            var scene = await handle.GetScene();
+
+            var sceneContext = scene.FindFirstObjectByType<SceneContext>();
+            if (!sceneContext)
+            {
+                await UnifiedSceneLoader.UnloadAsync(handle);
+                return ProjectContext.Instance;
+            }
+
+            while (!sceneContext.Loaded)
+            {
+                destroyCancellationToken.ThrowIfCancellationRequested();
+                await TaskHelper.NextFrame();
+            }
+
+            sceneContext.SceneContextLoader.AddChild(current);
+            return sceneContext;
+#else
+            return ProjectContext.Instance;
+#endif
+        }
+    }
+}

--- a/Runtime/Context/ParentSceneContextRequirement.cs.meta
+++ b/Runtime/Context/ParentSceneContextRequirement.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 91fe25ac099a42339769d062ef13acf4
+timeCreated: 1706711108

--- a/Runtime/Context/ProjectContext.cs
+++ b/Runtime/Context/ProjectContext.cs
@@ -31,6 +31,8 @@ namespace Doinject
         public SceneContextLoader OwnerSceneContextLoader => null;
         public SceneContextLoader SceneContextLoader { get; private set; }
         public GameObjectContextLoader GameObjectContextLoader { get; private set; }
+        public bool IsReverseLoaded => false;
+
 
 
         private void Initialize()

--- a/Runtime/Context/SceneContextLoader.cs
+++ b/Runtime/Context/SceneContextLoader.cs
@@ -112,6 +112,11 @@ namespace Doinject
             await Task.WhenAll(ChildSceneContexts.ToArray().Select(x => UnloadAsync(x).AsTask()));
         }
 
+        public void AddChild(SceneContext target)
+        {
+            ChildSceneContexts.Add(target);
+        }
+
         public ValueTask DisposeAsync()
         {
             if (this) Destroy(this);


### PR DESCRIPTION
closes #15 

To load dependent contexts, place ParentSceneContextRequirement component in SceneContext.

![image](https://github.com/mewlist/Doinject/assets/180818/f18ca9fc-e6f7-4994-bcef-488a56e9236c)


https://github.com/mewlist/Doinject/assets/180818/3fee7713-6700-4d7c-bed7-4404bf16c05b

