### PR TITLE
Fix document

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Install via Unity Package Manager
 Please install the packages in the following order:
 
 ```
-git@github.com:mewlist/MewCore.git
+https://github.com/mewlist/MewCore.git
 ```
 
 ```
-git@github.com:mewlist/Doinject.git
+https://github.com/mewlist/Doinject.git
 ```
 
 # About Doinject

--- a/README_ja.md
+++ b/README_ja.md
@@ -24,11 +24,11 @@ Asynchronous DI Container for Unity
 以下の順にパッケージをインストールしてください。
 
 ```
-git@github.com:mewlist/MewCore.git
+https://github.com/mewlist/MewCore.git
 ```
 
 ```
-git@github.com:mewlist/Doinject.git
+https://github.com/mewlist/Doinject.git
 ```
 
 # Doinject について

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "st.mewli.di",
   "displayName": "Doinject",
   "version": "1.0.0",
-  "unity": "2023.2",
+  "unity": "2022.3",
   "description": "Asynchronous DIContainer for Unity",
   "author": {
     "name": "mewlist",


### PR DESCRIPTION
upmのURLはgitプロトコルではインストールできないのでhttpsプロトコルへ修正しています。
また、package.jsonのunityは最低限必要なバージョンを指定するため2022.3へ修正しています。