### PR TITLE
Fix bug. Scene-Placed GameObjectContext do not wait for SceneContext loading.

### DIFF
--- a/Runtime/Context/GameObjectContext.cs
+++ b/Runtime/Context/GameObjectContext.cs
@@ -21,7 +21,17 @@ namespace Doinject
         {
             base.Awake();
             if (ContextSpaceScope.Scoped) return;
-            await Boot(FindParentContext());
+            var parentContext = FindParentContext();
+            switch (parentContext)
+            {
+                case null:
+                case SceneContext { Loaded: false }:
+                    // This context will be loaded by the parent scene context.
+                    return;
+                default:
+                    await Boot(FindParentContext());
+                    break;
+            }
         }
 
         private async void OnDestroy()
@@ -115,7 +125,9 @@ namespace Doinject
             }
 
             if (SceneContext.TryGetSceneContext(gameObject.scene, out var sceneContext))
+            {
                 return sceneContext;
+            }
 
             return ProjectContext.Instance;
         }

--- a/Tests/DynamicInjectionTest.cs
+++ b/Tests/DynamicInjectionTest.cs
@@ -18,11 +18,10 @@ namespace Doinject.Tests
         private string testGameObjectContextPrefabPath;
 
         [SetUp]
-        public async Task Setup()
+        public void Setup()
         {
             testScenePath = AssetDatabase.GUIDToAssetPath(TestSceneGuid);
             testGameObjectContextPrefabPath = AssetDatabase.GUIDToAssetPath(DynamicInjectionPrefabGuid);
-
         }
 
         [TearDown]

--- a/Tests/InjectionTest.cs
+++ b/Tests/InjectionTest.cs
@@ -154,7 +154,7 @@ namespace Doinject.Tests
             {
                 await container.ResolveAsync<PropertyInjectionWithNonPublicSetterComponent>();
             }
-            catch (Exception _)
+            catch (Exception)
             {
                 Assert.Pass();
             }


### PR DESCRIPTION
Context setup of Scene-Placed GameObjectContext do not wait for parent SceneContext loading.
 