### PR TITLE
Fix missing using statement on template file

### DIFF
--- a/Editor/BindingInstallerComponentTemplate.txt
+++ b/Editor/BindingInstallerComponentTemplate.txt
@@ -1,4 +1,5 @@
 using Doinject;
+using UnityEngine;
 
 public class #SCRIPTNAME# : MonoBehaviour, IBindingInstaller
 {


### PR DESCRIPTION
When creating a script from context menu `Create > Doinject > Binding Installer Component C# Script`, the generated .cs file had a missing using statement and generates compile error by default.

Fixed by adding `using UnityEngine;` statement on template file.