### PR TITLE
Fix: Error on DIContextTree 

### DIFF
--- a/Editor/Context/ContextTracker/ContextTreeWindow.cs
+++ b/Editor/Context/ContextTracker/ContextTreeWindow.cs
@@ -105,17 +105,26 @@ namespace Doinject.Context
 
         private void OnTreeItemSelected(IEnumerable<object> selection)
         {
-            selectedNode = selection.First() as ContextNode;
-            bindingDataSource = selectedNode.Context.RawContainer.ReadOnlyBindings.ToList();
-            var id = 0;
-            treeViewDataSource = selectedNode.Context.RawContainer.ReadOnlyBindings
-                .Select(x =>
-                    new TreeViewItemData<Item>(id++,
-                        new Item {
-                            Type = x.Key,
-                            Resolver = x.Value,
-                        }))
-                .ToList();
+            selectedNode = selection.FirstOrDefault() as ContextNode;
+            if (selectedNode is not null)
+            {
+                bindingDataSource = selectedNode.Context.RawContainer.ReadOnlyBindings.ToList();
+                var id = 0;
+                treeViewDataSource = selectedNode.Context.RawContainer.ReadOnlyBindings
+                    .Select(x =>
+                        new TreeViewItemData<Item>(id++,
+                            new Item {
+                                Type = x.Key,
+                                Resolver = x.Value,
+                            }))
+                    .ToList();
+            }
+            else
+            {
+                bindingDataSource = new List<KeyValuePair<TargetTypeInfo, IInternalResolver>>();
+                treeViewDataSource = new List<TreeViewItemData<Item>>();
+            }
+
             instancesView.SetRootItems(treeViewDataSource);
             instancesView.Rebuild();
         }

--- a/Runtime/Context/SceneContext.cs
+++ b/Runtime/Context/SceneContext.cs
@@ -125,15 +125,12 @@ namespace Doinject
                     await TaskHelper.NextFrame(destroyCancellationToken);
 
             }
-            catch (Exception _)
+            catch (Exception)
             {
-                if (ParentContext is not null && !ParentContext.Loaded)
-                {
-                    Debug.LogWarning("Parent context is not loaded. Shutdown SceneContext.");
-                    await Shutdown();
-                    return;
-                }
-                throw;
+                if (ParentContext is null || ParentContext.Loaded) throw;
+                Debug.LogWarning("Parent context is not loaded. Shutdown SceneContext.");
+                await Shutdown();
+                return;
             }
             using (new ContextSpaceScope(this))
             {

--- a/Runtime/Installer/BindingInstallerComponent.cs
+++ b/Runtime/Installer/BindingInstallerComponent.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
@@ -59,6 +60,14 @@ namespace Doinject
 
             foreach (var component in ComponentBindings)
             {
+                if (component is null)
+                {
+                    Debug.LogException(
+                        new ArgumentException("Null binding found on BindingInstallerComponent.", nameof(ComponentBindings)),
+                        this);
+                    continue;
+                }
+
                 var componentType = component.GetType();
                 var genericMethod = method.MakeGenericMethod(componentType);
                 genericMethod.Invoke(container, new object[] { component });


### PR DESCRIPTION
* Fixes error on ContextTreeWindow when node is not selected.
* Outputs understandable error log when null reference found in BindingInstallerComponent.ComponentBindings.