### PR TITLE
Output FailedToInject exception message to console.

### DIFF
--- a/Runtime/DIContainer.cs
+++ b/Runtime/DIContainer.cs
@@ -197,16 +197,7 @@ namespace Doinject
                 targetMethodsInfo = GetTargetMethodInfo(targetType);
                 targetPropertiesInfo = GetTargetPropertyInfo(targetType);
                 targetFieldsInfo = GetTargetFieldInfo(targetType);
-            }
-            catch (Exception e)
-            {
-                InjectionProcessingScope.End();
-                AfterInjectionProcessingScope.End();
-                throw new FailedToInjectException(target, e);
-            }
 
-            try
-            {
                 await TaskHelper.WhenAll(
                     MethodInjector.DoInject(target, targetMethodsInfo, args, scopedInstances),
                     PropertyInjector.DoInject(target, targetPropertiesInfo),
@@ -216,8 +207,11 @@ namespace Doinject
             {
                 InjectionProcessingScope.End();
                 AfterInjectionProcessingScope.End();
-                throw new FailedToInjectException(target, e);
+                var exception = new FailedToInjectException(target, e);
+                Debug.LogError(exception);
+                throw exception;
             }
+
             TryMarkInjected(targetType);
 
             InjectionProcessingScope.End();
@@ -308,16 +302,7 @@ namespace Doinject
                 targetMethodsInfo = GetTargetMethodInfo(targetType);
                 targetPropertiesInfo = GetTargetPropertyInfo(targetType);
                 targetFieldsInfo = GetTargetFieldInfo(targetType);
-            }
-            catch (Exception e)
-            {
-                InjectionProcessingScope.End();
-                AfterInjectionProcessingScope.End();
-                throw new FailedToInjectException(target, e);
-            }
 
-            try
-            {
                 await TaskHelper.WhenAll(
                     MethodInjector.DoInject(target, targetMethodsInfo, args, scopedInstances),
                     PropertyInjector.DoInject(target, targetPropertiesInfo),
@@ -327,8 +312,11 @@ namespace Doinject
             {
                 InjectionProcessingScope.End();
                 AfterInjectionProcessingScope.End();
-                throw new FailedToInjectException(target, e);
+                var exception = new FailedToInjectException(target, e);
+                Debug.LogError(exception);
+                throw exception;
             }
+
             TryMarkInjected(targetType);
 
             InjectionProcessingScope.End();

--- a/Tests/ExceptionTestScope.cs
+++ b/Tests/ExceptionTestScope.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using UnityEngine.TestTools;
+
+namespace Doinject.Tests
+{
+    public class ExceptionTestScope : IDisposable
+    {
+        private readonly bool currentValue;
+
+        public ExceptionTestScope()
+        {
+            currentValue = LogAssert.ignoreFailingMessages;
+            LogAssert.ignoreFailingMessages = true;
+        }
+
+        public void Dispose()
+        {
+            LogAssert.ignoreFailingMessages = currentValue;
+        }
+    }
+}

--- a/Tests/ExceptionTestScope.cs.meta
+++ b/Tests/ExceptionTestScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 50ef79bfa8b041dca84eea5c7acc9d0b
+timeCreated: 1732332313

--- a/Tests/InjectionTest.cs
+++ b/Tests/InjectionTest.cs
@@ -73,6 +73,8 @@ namespace Doinject.Tests
         [Test]
         public void BindingNotFoundTest()
         {
+            using var exceptionTestScope = new ExceptionTestScope();
+
             container.BindTransient<MethodInjectionTestClass>();
             Assert.IsTrue(container.HasBinding<MethodInjectionTestClass>());
             Assert.ThrowsAsync<FailedToResolveException>(async () =>
@@ -148,6 +150,8 @@ namespace Doinject.Tests
         [Test]
         public async Task PropertyInjectionWithNonPublicSetterComponentTest()
         {
+            using var exceptionTestScope = new ExceptionTestScope();
+
             container.BindTransient<PropertyInjectionWithNonPublicSetterComponent>();
             container.BindTransient<InjectedObject>();
             try
@@ -182,6 +186,8 @@ namespace Doinject.Tests
         [Test]
         public async Task FieldInjectionWithNonPublicSetterComponentTest()
         {
+            using var exceptionTestScope = new ExceptionTestScope();
+
             container.BindTransient<FieldInjectionWithNonPublicObject>();
             container.BindTransient<InjectedObject>();
             try

--- a/Tests/TickableTest.cs
+++ b/Tests/TickableTest.cs
@@ -55,6 +55,8 @@ namespace Doinject.Tests
         [Test]
         public async Task InvalidTickableTest()
         {
+            using var exceptionTestScope = new ExceptionTestScope();
+
             try
             {
                 container.Bind<InvalidTickableObject>();


### PR DESCRIPTION
If an exception occurs when injecting, it is difficult to notice the cause, so FailedToInjection exceptions are now always displayed as errors on the console.