### PR TITLE
Fix race condition of addressables asset loading

### DIFF
--- a/Runtime/Assets/Resolvers/AddressableAssetResolver.cs
+++ b/Runtime/Assets/Resolvers/AddressableAssetResolver.cs
@@ -44,7 +44,12 @@ namespace Doinject.Assets
             T instance = default;
             await TaskQueue.EnqueueAsync(async ct =>
             {
-                if (Instance is not null) return;
+                if (Instance is not null)
+                {
+                    // Already loaded
+                    instance = Instance;
+                    return;
+                }
                 instance = await AssetLoader.LoadAsync<T>(RuntimeKey, ct);
             }).OnException(Debug.LogException);
             return instance;


### PR DESCRIPTION
# Problems

* Injecting Addressables Assets instances into many instances at the same time can cause the Injection to fail.

